### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.0
         with:
           # Default secrets.GITHUB_TOKEN does not have workflow access
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
