### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # Default secrets.GITHUB_TOKEN does not have workflow access
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v4.1.0
         with:
           go-version: 1.20.6
       - name: Run go vet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v4.0.1
+      - uses: actions/setup-go@v4.1.0
         with:
           go-version: 1.20.6
-      - uses: goreleaser/goreleaser-action@v4.3.0
+      - uses: goreleaser/goreleaser-action@v4.4.0
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action)** published a new release **[v4.4.0](https://github.com/goreleaser/goreleaser-action/releases/tag/v4.4.0)** on 2023-08-09T17:04:31Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v4.1.0](https://github.com/actions/setup-go/releases/tag/v4.1.0)** on 2023-08-08T12:04:32Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
