### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.0.0
         with:
           # Default secrets.GITHUB_TOKEN does not have workflow access
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # Default secrets.GITHUB_TOKEN does not have workflow access
           token: ${{ secrets.ACTION_UPDATER_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,16 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.0.0
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v4.1.0
         with:
           go-version: 1.20.6
       - name: Run go vet
         run: go vet ./...
       - name: Run go build
         run: go build -v ./...
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v3.8.1
         with:
           node-version: 18.17.0
       - name: Install @hashgraph/hedera-local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v4.0.1
+      - uses: actions/setup-go@v4.1.0
         with:
           go-version: 1.20.6
-      - uses: goreleaser/goreleaser-action@v4.3.0
+      - uses: goreleaser/goreleaser-action@v5.0.0
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v4.1.0](https://github.com/actions/setup-go/releases/tag/v4.1.0)** on 2023-08-08T12:04:32Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.8.1](https://github.com/actions/setup-node/releases/tag/v3.8.1)** on 2023-08-17T13:14:07Z
* **[goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action)** published a new release **[v5.0.0](https://github.com/goreleaser/goreleaser-action/releases/tag/v5.0.0)** on 2023-09-11T18:09:55Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
